### PR TITLE
Specify new C++ ABI, and build packages that can't be found

### DIFF
--- a/fetch_dependencies.sh
+++ b/fetch_dependencies.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-conan install . --install-folder build --build=gtest
+conan install . --install-folder build -s compiler.libcxx=libstdc++11 --build missing


### PR DESCRIPTION
Tell conan what version of the C++ ABI we need, and instead of always building gtest, build any packages that can't be downloaded automatically.

Tested on an x86_64 system running Ubuntu 20.04