### PR TITLE
Bugfix/log seh exception

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ on:
 env:
   # Defaults
   DEFAULT_BUILD_TYPE: 'Release'
-  DEFAULT_JOB_FILTER: 'windows'
+  DEFAULT_JOB_FILTER: ''
   DEFAULT_LOG_LEVEL: 'info'
   DEFAULT_VERBOSE: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ on:
 env:
   # Defaults
   DEFAULT_BUILD_TYPE: 'Release'
-  DEFAULT_JOB_FILTER: ''
+  DEFAULT_JOB_FILTER: 'windows'
   DEFAULT_LOG_LEVEL: 'info'
   DEFAULT_VERBOSE: false
 

--- a/lib/cmake/module/AddLocalAllTarget.cmake
+++ b/lib/cmake/module/AddLocalAllTarget.cmake
@@ -1,15 +1,15 @@
 include_guard()
 
-function(add_local_all_target target_name)
+function(add_local_all_target name)
 	get_directory_property(targets BUILDSYSTEM_TARGETS)
 
 	string(JOIN " " pretty_targets ${targets})
-	message(DEBUG "Adding target ${target_name} with: ${pretty_targets}")
+	message(DEBUG "Adding target ${name} with: ${pretty_targets}")
 
 	foreach(target IN LISTS targets)
 		list(APPEND argv "COMMAND;${target}")
 	endforeach()
 
-	add_custom_target(${target_name} ${argv} VERBATIM)
-	add_dependencies(${target_name} ${targets})
+	add_custom_target(${name} ${argv} VERBATIM)
+	add_dependencies(${name} ${targets})
 endfunction()

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -45,9 +45,9 @@ include(project-config)
 set(CMAKE_MSVCIDE_RUN_PATH "${package_root}/bin")
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL" CACHE STRING "MSVC runtime")
 
-set(target_name main)
+set(target main)
 
-add_executable(${target_name})
+add_executable(${target})
 
 include(sources.cmake)
 
@@ -58,6 +58,6 @@ target_link_libraries(main
 )
 
 add_custom_target(run
-	COMMAND ${target_name} > ${target_name}.txt
-	COMMAND ${CMAKE_COMMAND} -E cat ${target_name}.txt
+	COMMAND ${target} > ${target}.txt
+	COMMAND ${CMAKE_COMMAND} -E cat ${target}.txt
 )

--- a/sample/sources.cmake
+++ b/sample/sources.cmake
@@ -3,19 +3,19 @@
 	- sample/CMakeLists.txt
 	- sample/targets.cmake
 
-	To each, ${target_name} refers to a separate target.
+	To each, ${target} refers to a separate target.
 ]]
 
 set(source_dir "${CMAKE_CURRENT_LIST_DIR}")
 
-target_sources(${target_name}  # parent scope defines ${target_name}
+target_sources(${target}  # parent scope defines ${target}
 	PRIVATE
 		${source_dir}/main.cxx
 
 		${source_dir}/cli.cxx
 		${source_dir}/cli.hxx
 )
-target_include_directories(${target_name}
+target_include_directories(${target}
 	PRIVATE
 		${CMAKE_CURRENT_LIST_DIR}
 )

--- a/sample/targets.cmake
+++ b/sample/targets.cmake
@@ -5,25 +5,25 @@ set(binary_dir "${PROJECT_BINARY_DIR}/sample")
 #  External sample  #
 #####################
 
-set(target_name "app-sample")
+set(target "app-sample")
 
-add_custom_target(${target_name}
+add_custom_target(${target}
 	COMMAND ${CMAKE_COMMAND} -S "${source_dir}" -B "${binary_dir}" -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}"  # --log-level=DEBUG
 	COMMAND ${CMAKE_COMMAND} --build "${binary_dir}" --config $<CONFIG> --parallel --target run
 )
-add_dependencies(${target_name} build-package)
+add_dependencies(${target} build-package)
 
 #####################
 #  Internal sample  #
 #####################
 
-set(target_name "app-console")
+set(target "app-console")
 
-add_executable(${target_name})
+add_executable(${target})
 
 include(${source_dir}/sources.cmake)
 
-target_link_libraries(${target_name}
+target_link_libraries(${target}
 	PRIVATE
 		project
 		cxxopts::cxxopts

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,29 +1,29 @@
-set(target_name "project")
+set(target "project")
 
 configure_file("version.h.in" "version.h")
 
-add_library(${target_name}
+add_library(${target}
 	project.cxx
 	${CMAKE_CURRENT_BINARY_DIR}/version.h
 )
 
 add_subdirectory(utility)
 
-target_include_directories(${target_name}
+target_include_directories(${target}
 	PUBLIC
 		$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
 		$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
 		$<INSTALL_INTERFACE:include>
 )
-target_link_libraries(${target_name}
+target_link_libraries(${target}
 	PUBLIC
 		fmt::fmt
 )
-target_compile_features(${target_name}
+target_compile_features(${target}
 	PUBLIC
 		cxx_std_${CMAKE_CXX_STANDARD}
 )
-target_compile_options(${target_name}
+target_compile_options(${target}
 	PRIVATE
 		# https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_ID.html
 		$<$<CXX_COMPILER_ID:MSVC>:/W4>
@@ -36,8 +36,8 @@ set(header_files_to_package
 	"${CMAKE_CURRENT_LIST_DIR}/utility/log.hxx"
 )
 
-set_target_properties(${target_name} PROPERTIES
+set_target_properties(${target} PROPERTIES
 	PUBLIC_HEADER "${header_files_to_package}"
 )
 
-project_dll_export(${target_name})
+project_dll_export(${target})

--- a/src/utility/CMakeLists.txt
+++ b/src/utility/CMakeLists.txt
@@ -1,13 +1,13 @@
-target_sources(${target_name}  # parent scope defines ${target_name}
+target_sources(${target}  # parent scope defines ${target}
 	PRIVATE
 		log.cxx
 		log.hxx
 )
-target_include_directories(${target_name}
+target_include_directories(${target}
 	PUBLIC
 		$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
 )
-target_compile_definitions(${target_name}
+target_compile_definitions(${target}
 	PUBLIC
 		$<$<CONFIG:Debug>:ENABLE_LOGGING>
 )

--- a/src/utility/log.cxx
+++ b/src/utility/log.cxx
@@ -65,19 +65,19 @@ auto get_target() -> std::FILE*
 void print_enabled_levels()
 {
 	// clang-format off
-	auto constexpr error   {level_label(Level::Error)};
-	auto constexpr warning {level_label(Level::Warning)};
-	auto constexpr info    {level_label(Level::Info)};
-	auto constexpr debug   {level_label(Level::Debug)};
-	auto constexpr trace   {level_label(Level::Trace)};
-	auto constexpr none    {level_label(Level::None)};
+	static auto constexpr error   {level_label(Level::Error)};
+	static auto constexpr warning {level_label(Level::Warning)};
+	static auto constexpr info    {level_label(Level::Info)};
+	static auto constexpr debug   {level_label(Level::Debug)};
+	static auto constexpr trace   {level_label(Level::Trace)};
+	static auto constexpr none    {level_label(Level::None)};
 
 	std::string levels {fmt::format("{}, {}, {}, {}, {}", error, warning, info, debug, trace)};
 
-	auto constexpr error_end    {              error.size()      };
-	auto constexpr warning_end  {error_end   + warning.size() + 2};  // +2 for ", "
-	auto constexpr info_end     {warning_end + info.size()    + 2};
-	auto constexpr debug_end    {info_end    + debug.size()   + 2};
+	static auto constexpr error_end    {              error.size()      };
+	static auto constexpr warning_end  {error_end   + warning.size() + 2};  // +2 for ", "
+	static auto constexpr info_end     {warning_end + info.size()    + 2};
+	static auto constexpr debug_end    {info_end    + debug.size()   + 2};
 	// auto constexpr trace_end {debug_end   + trace.size()   + 2};
 
 	char const* msg_ptr {levels.data()};
@@ -87,7 +87,7 @@ void print_enabled_levels()
 	case Level::Warning: levels[warning_end] = '\0'; break;
 	case Level::Info:    levels[info_end]    = '\0'; break;
 	case Level::Debug:   levels[debug_end]   = '\0'; break;
-	case Level::Trace: /* levels[trace_end] = '\0' */; break;
+	case Level::Trace: /* levels[trace_end] = '\0'; */ break;
 	case Level::None: msg_ptr = none.data(); break;
 	}
 	// clang-format on

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -4,7 +4,7 @@ find_package(Threads)
 
 if(Threads_FOUND)
 	message(DEBUG "Linking ${target} to Threads library")
-	set(Threads_lib Threads::Threads)
+	log_vars(CMAKE_THREAD_LIBS_INIT)
 endif()
 
 add_google_executable(${target}
@@ -14,7 +14,7 @@ add_google_executable(${target}
 
 	LIBRARIES
 		project
-		${Threads_lib}
+		${CMAKE_THREAD_LIBS_INIT}
 )
 
 add_local_all_target(all-unit)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,5 +1,12 @@
 set(target unit-project)
 
+find_package(Threads)
+
+if(Threads_FOUND)
+	message(DEBUG "Linking ${target} to Threads library")
+	set(threads Threads::Threads)
+endif()
+
 add_google_executable(${target}
 	SOURCES
 		log.cxx
@@ -7,6 +14,7 @@ add_google_executable(${target}
 
 	LIBRARIES
 		project
+		${threads}
 )
 
 add_local_all_target(all-unit)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,12 +1,5 @@
 set(target unit-project)
 
-find_package(Threads)
-
-if(Threads_FOUND)
-	message(DEBUG "Linking ${target} to Threads library")
-	set(threads Threads::Threads)
-endif()
-
 add_google_executable(${target}
 	SOURCES
 		log.cxx
@@ -14,7 +7,6 @@ add_google_executable(${target}
 
 	LIBRARIES
 		project
-		${threads}
 )
 
 add_local_all_target(all-unit)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,12 +1,5 @@
 set(target unit-project)
 
-find_package(Threads)
-
-if(Threads_FOUND)
-	message(DEBUG "Linking ${target} to Threads library")
-	log_vars(CMAKE_THREAD_LIBS_INIT)
-endif()
-
 add_google_executable(${target}
 	SOURCES
 		log.cxx
@@ -14,7 +7,6 @@ add_google_executable(${target}
 
 	LIBRARIES
 		project
-		${CMAKE_THREAD_LIBS_INIT}
 )
 
 add_local_all_target(all-unit)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,10 +1,20 @@
-add_google_executable(unit-project
+set(target unit-project)
+
+find_package(Threads)
+
+if(Threads_FOUND)
+	message(DEBUG "Linking ${target} to Threads library")
+	set(Threads_lib Threads::Threads)
+endif()
+
+add_google_executable(${target}
 	SOURCES
 		log.cxx
 		project.cxx
 
 	LIBRARIES
 		project
+		${Threads_lib}
 )
 
 add_local_all_target(all-unit)

--- a/test/unit/log.cxx
+++ b/test/unit/log.cxx
@@ -7,6 +7,12 @@
 
 using namespace project;
 
+auto mutex_ref() -> std::mutex&
+{
+	static std::mutex mutex {};
+	return mutex;
+}
+
 class Log : public ::testing::Test
 {
 protected:
@@ -14,20 +20,16 @@ protected:
 	{
 		// These tests change and depend on the global log level,
 		// so lock a mutex between tests to prevent interference.
-		_mutex.lock();
+		mutex_ref().lock();
 		log::set_target(stderr);
 		log::set_level(log::Level::None);
 	}
 
 	void TearDown() override
 	{
-		_mutex.unlock();
+		mutex_ref().unlock();
 	}
-
-	static std::mutex _mutex;
 };
-
-std::mutex Log::_mutex {};
 
 TEST_F(Log, error)
 {

--- a/test/unit/log.cxx
+++ b/test/unit/log.cxx
@@ -7,8 +7,6 @@
 
 using namespace project;
 
-static std::mutex Mutex {};
-
 class Log : public ::testing::Test
 {
 protected:
@@ -16,16 +14,20 @@ protected:
 	{
 		// These tests change and depend on the global log level,
 		// so lock a mutex between tests to prevent interference.
-		Mutex.lock();
+		_mutex.lock();
 		log::set_target(stderr);
 		log::set_level(log::Level::None);
 	}
 
 	void TearDown() override
 	{
-		Mutex.unlock();
+		_mutex.unlock();
 	}
+
+	static std::mutex _mutex;
 };
+
+std::mutex Log::_mutex {};
 
 TEST_F(Log, error)
 {

--- a/test/unit/log.cxx
+++ b/test/unit/log.cxx
@@ -14,14 +14,14 @@ protected:
 	{
 		// These tests change and depend on the global log level,
 		// so lock a mutex between tests to prevent interference.
-		_mutex.lock();
+		//_mutex.lock();
 		log::set_target(stderr);
 		log::set_level(log::Level::None);
 	}
 
 	void TearDown() override
 	{
-		_mutex.unlock();
+		//_mutex.unlock();
 	}
 
 	static std::mutex _mutex;

--- a/test/unit/log.cxx
+++ b/test/unit/log.cxx
@@ -7,6 +7,10 @@
 
 using namespace project;
 
+#if !GTEST_IS_THREADSAFE
+#error "test"
+#endif
+
 auto mutex_ref() -> std::mutex&
 {
 	static std::mutex mutex {};

--- a/test/unit/log.cxx
+++ b/test/unit/log.cxx
@@ -5,10 +5,6 @@
 
 using namespace project;
 
-#include <mutex>
-
-static std::mutex Mutex;
-
 class Log : public ::testing::Test
 {
 protected:
@@ -21,7 +17,6 @@ protected:
 
 TEST_F(Log, error)
 {
-	std::lock_guard<std::mutex> lock {Mutex};
 	log::set_level(log::Level::Error);
 	ASSERT_EQ(log::Level::Error, log::get_level());
 	::testing::internal::CaptureStderr();

--- a/test/unit/log.cxx
+++ b/test/unit/log.cxx
@@ -27,7 +27,7 @@ protected:
 	static std::mutex _mutex;
 };
 
-std::mutex Log::_mutex {};
+std::mutex Log::_mutex;
 
 TEST_F(Log, error)
 {

--- a/test/unit/log.cxx
+++ b/test/unit/log.cxx
@@ -1,37 +1,17 @@
 #include <gtest/gtest.h>
 
-#include <mutex>
-
 #define ENABLE_LOGGING 1
 #include <log.hxx>
 
 using namespace project;
-
-#if !GTEST_IS_THREADSAFE
-#error "test"
-#endif
-
-auto mutex_ref() -> std::mutex&
-{
-	static std::mutex mutex {};
-	return mutex;
-}
 
 class Log : public ::testing::Test
 {
 protected:
 	void SetUp() override
 	{
-		// These tests change and depend on the global log level,
-		// so lock a mutex between tests to prevent interference.
-		mutex_ref().lock();
 		log::set_target(stderr);
 		log::set_level(log::Level::None);
-	}
-
-	void TearDown() override
-	{
-		mutex_ref().unlock();
 	}
 };
 

--- a/test/unit/log.cxx
+++ b/test/unit/log.cxx
@@ -5,6 +5,10 @@
 
 using namespace project;
 
+#include <mutex>
+
+static std::mutex Mutex;
+
 class Log : public ::testing::Test
 {
 protected:
@@ -17,6 +21,7 @@ protected:
 
 TEST_F(Log, error)
 {
+	std::lock_guard<std::mutex> lock {Mutex};
 	log::set_level(log::Level::Error);
 	ASSERT_EQ(log::Level::Error, log::get_level());
 	::testing::internal::CaptureStderr();

--- a/test/unit/log.cxx
+++ b/test/unit/log.cxx
@@ -27,7 +27,7 @@ protected:
 	static std::mutex _mutex;
 };
 
-std::mutex Log::_mutex;
+std::mutex Log::_mutex {};
 
 TEST_F(Log, error)
 {

--- a/test/unit/log.cxx
+++ b/test/unit/log.cxx
@@ -7,6 +7,8 @@
 
 using namespace project;
 
+static std::mutex Mutex {};
+
 class Log : public ::testing::Test
 {
 protected:
@@ -14,20 +16,16 @@ protected:
 	{
 		// These tests change and depend on the global log level,
 		// so lock a mutex between tests to prevent interference.
-		//_mutex.lock();
+		Mutex.lock();
 		log::set_target(stderr);
 		log::set_level(log::Level::None);
 	}
 
 	void TearDown() override
 	{
-		//_mutex.unlock();
+		Mutex.unlock();
 	}
-
-	static std::mutex _mutex;
 };
-
-std::mutex Log::_mutex {};
 
 TEST_F(Log, error)
 {


### PR DESCRIPTION
Remove mutex lock around log tests--probably not ever truly multithreaded anyway.

Not sure why these tests suddenly started failing on Windows. I think it was an update to the runner software on windows-latest, because a lot of older runs suddenly began to fail when I re-ran them.

Needs further investigation, and I'm unable to replicate locally, so I'll wait until I know these test are definitely a problem first.